### PR TITLE
Fix the selection highlighter in walker

### DIFF
--- a/walker.css
+++ b/walker.css
@@ -4,3 +4,10 @@
 @define-color border #CC990088;
 @define-color foreground #FFB000;
 @define-color background #0A0A08;
+@define-color selection-highlight #FFCC00;
+
+child:selected,
+child:hover {
+  background: @selection-highlight;
+  color: @selected-text;
+}


### PR DESCRIPTION
Addresses issue #1

Before:

<img width="325" height="735" alt="image" src="https://github.com/user-attachments/assets/e53e917a-d1d9-412f-b234-5959dbc7f144" />

After:

<img width="333" height="747" alt="image" src="https://github.com/user-attachments/assets/c6bb7a19-1403-44fb-90d6-796bc2643472" />
